### PR TITLE
Buy nsell

### DIFF
--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -10,6 +10,11 @@ path = 'contracts/CoreMarketPlace.clar'
 clarity_version = 2
 epoch = 2.5
 
+[contracts.UserProfile]
+path = 'contracts/UserProfile.clar'
+clarity_version = 2
+epoch = 2.5
+
 [contracts.token]
 path = 'contracts/token.clar'
 clarity_version = 2

--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -10,6 +10,11 @@ path = 'contracts/CoreMarketPlace.clar'
 clarity_version = 2
 epoch = 2.5
 
+[contracts.EscrowService]
+path = 'contracts/EscrowService.clar'
+clarity_version = 2
+epoch = 2.5
+
 [contracts.UserProfile]
 path = 'contracts/UserProfile.clar'
 clarity_version = 2

--- a/contracts/EscrowService.clar
+++ b/contracts/EscrowService.clar
@@ -1,43 +1,51 @@
 ;; EscrowService: Manages secure transactions between buyers and sellers
 
-;; Constants
+;; Define constants
 (define-constant CONTRACT_OWNER tx-sender)
 (define-constant ERR_NOT_AUTHORIZED (err u100))
 (define-constant ERR_ESCROW_NOT_FOUND (err u101))
-(define-constant ERR_INVALID_AMOUNT (err u102))
-(define-constant ERR_INSUFFICIENT_BALANCE (err u103))
-(define-constant ERR_ALREADY_RELEASED (err u104))
-(define-constant ERR_NOT_BUYER_OR_SELLER (err u105))
-(define-constant ERR_TOO_EARLY_TO_RELEASE (err u106))
-(define-constant ERR_INVALID_STATE (err u107))
-(define-constant ERR_TRANSFER_FAILED (err u108))
-(define-constant ESCROW_LOCK_PERIOD u144) ;; 24 hours in blocks (assuming 10-minute block times)
+(define-constant ERR_ALREADY_RELEASED (err u102))
+(define-constant ERR_TRANSFER_FAILED (err u103))
+(define-constant ERR_INVALID_ESCROW_ID (err u104))
+(define-constant ERR_INVALID_AMOUNT (err u105))
+(define-constant ERR_INVALID_SELLER (err u106))
 
-;; Data Maps
+;; Define data maps
 (define-map Escrows
   { escrow-id: uint }
   {
     buyer: principal,
     seller: principal,
     amount: uint,
-    state: (string-ascii 20),
-    created-at: uint,
-    release-height: uint
+    state: (string-ascii 10)
   }
 )
 
+;; Define variables
 (define-data-var last-escrow-id uint u0)
 
-;; Public Functions
+;; Helper functions
+(define-private (is-valid-seller (seller principal))
+  (and 
+    (not (is-eq seller tx-sender))
+    (not (is-eq seller (as-contract tx-sender)))
+  )
+)
+
+(define-private (is-valid-escrow-id (escrow-id uint))
+  (<= escrow-id (var-get last-escrow-id))
+)
+
+;; Create a new escrow
 (define-public (create-escrow (seller principal) (amount uint))
   (let
     (
       (escrow-id (+ (var-get last-escrow-id) u1))
-      (release-height (+ block-height ESCROW_LOCK_PERIOD))
     )
     (asserts! (> amount u0) (err ERR_INVALID_AMOUNT))
+    (asserts! (is-valid-seller seller) (err ERR_INVALID_SELLER))
     (match (stx-transfer? amount tx-sender (as-contract tx-sender))
-      success 
+      success
         (begin
           (map-set Escrows
             { escrow-id: escrow-id }
@@ -45,74 +53,83 @@
               buyer: tx-sender,
               seller: seller,
               amount: amount,
-              state: "locked",
-              created-at: block-height,
-              release-height: release-height
+              state: "locked"
             }
           )
           (var-set last-escrow-id escrow-id)
-          (ok escrow-id))
+          (ok escrow-id)
+        )
       error (err ERR_TRANSFER_FAILED)
     )
   )
 )
 
+;; Release funds to the seller
 (define-public (release-funds (escrow-id uint))
-  (let
-    (
-      (escrow (unwrap! (map-get? Escrows { escrow-id: escrow-id }) (err ERR_ESCROW_NOT_FOUND)))
-      (buyer (get buyer escrow))
-      (seller (get seller escrow))
-      (amount (get amount escrow))
-    )
-    (asserts! (or (is-eq tx-sender buyer) (is-eq tx-sender seller)) (err ERR_NOT_BUYER_OR_SELLER))
-    (asserts! (is-eq (get state escrow) "locked") (err ERR_ALREADY_RELEASED))
-    (asserts! (>= block-height (get release-height escrow)) (err ERR_TOO_EARLY_TO_RELEASE))
-    (match (as-contract (stx-transfer? amount tx-sender seller))
-      success 
-        (begin
-          (map-set Escrows
-            { escrow-id: escrow-id }
-            (merge escrow { state: "released" })
+  (begin
+    (asserts! (is-valid-escrow-id escrow-id) (err ERR_INVALID_ESCROW_ID))
+    (let
+      (
+        (escrow (unwrap! (map-get? Escrows { escrow-id: escrow-id }) (err ERR_ESCROW_NOT_FOUND)))
+        (seller (get seller escrow))
+        (amount (get amount escrow))
+      )
+      (asserts! (is-eq tx-sender CONTRACT_OWNER) (err ERR_NOT_AUTHORIZED))
+      (asserts! (is-eq (get state escrow) "locked") (err ERR_ALREADY_RELEASED))
+      (match (as-contract (stx-transfer? amount tx-sender seller))
+        success 
+          (begin
+            (map-set Escrows
+              { escrow-id: escrow-id }
+              (merge escrow { state: "released" })
+            )
+            (ok true)
           )
-          (ok true))
-      error (err ERR_TRANSFER_FAILED)
+        error (err ERR_TRANSFER_FAILED)
+      )
     )
   )
 )
 
+;; Refund buyer
 (define-public (refund-buyer (escrow-id uint))
-  (let
-    (
-      (escrow (unwrap! (map-get? Escrows { escrow-id: escrow-id }) (err ERR_ESCROW_NOT_FOUND)))
-      (buyer (get buyer escrow))
-      (amount (get amount escrow))
-    )
-    (asserts! (is-eq tx-sender CONTRACT_OWNER) (err ERR_NOT_AUTHORIZED))
-    (asserts! (is-eq (get state escrow) "locked") (err ERR_ALREADY_RELEASED))
-    (match (as-contract (stx-transfer? amount tx-sender buyer))
-      success 
-        (begin
-          (map-set Escrows
-            { escrow-id: escrow-id }
-            (merge escrow { state: "refunded" })
+  (begin
+    (asserts! (is-valid-escrow-id escrow-id) (err ERR_INVALID_ESCROW_ID))
+    (let
+      (
+        (escrow (unwrap! (map-get? Escrows { escrow-id: escrow-id }) (err ERR_ESCROW_NOT_FOUND)))
+        (buyer (get buyer escrow))
+        (amount (get amount escrow))
+      )
+      (asserts! (is-eq tx-sender CONTRACT_OWNER) (err ERR_NOT_AUTHORIZED))
+      (asserts! (is-eq (get state escrow) "locked") (err ERR_ALREADY_RELEASED))
+      (match (as-contract (stx-transfer? amount tx-sender buyer))
+        success 
+          (begin
+            (map-set Escrows
+              { escrow-id: escrow-id }
+              (merge escrow { state: "refunded" })
+            )
+            (ok true)
           )
-          (ok true))
-      error (err ERR_TRANSFER_FAILED)
+        error (err ERR_TRANSFER_FAILED)
+      )
     )
   )
 )
 
+;; Get escrow details
 (define-read-only (get-escrow (escrow-id uint))
-  (map-get? Escrows { escrow-id: escrow-id })
+  (begin
+    (asserts! (is-valid-escrow-id escrow-id) (err ERR_INVALID_ESCROW_ID))
+    (match (map-get? Escrows { escrow-id: escrow-id })
+      escrow (ok escrow)
+      (err ERR_ESCROW_NOT_FOUND)
+    )
+  )
 )
 
+;; Get last escrow ID
 (define-read-only (get-last-escrow-id)
   (ok (var-get last-escrow-id))
-)
-
-;; Initialize contract
-(begin
-  (print "EscrowService contract initialized")
-  (ok true)
 )

--- a/contracts/EscrowService.clar
+++ b/contracts/EscrowService.clar
@@ -1,0 +1,118 @@
+;; EscrowService: Manages secure transactions between buyers and sellers
+
+;; Constants
+(define-constant CONTRACT_OWNER tx-sender)
+(define-constant ERR_NOT_AUTHORIZED (err u100))
+(define-constant ERR_ESCROW_NOT_FOUND (err u101))
+(define-constant ERR_INVALID_AMOUNT (err u102))
+(define-constant ERR_INSUFFICIENT_BALANCE (err u103))
+(define-constant ERR_ALREADY_RELEASED (err u104))
+(define-constant ERR_NOT_BUYER_OR_SELLER (err u105))
+(define-constant ERR_TOO_EARLY_TO_RELEASE (err u106))
+(define-constant ERR_INVALID_STATE (err u107))
+(define-constant ERR_TRANSFER_FAILED (err u108))
+(define-constant ESCROW_LOCK_PERIOD u144) ;; 24 hours in blocks (assuming 10-minute block times)
+
+;; Data Maps
+(define-map Escrows
+  { escrow-id: uint }
+  {
+    buyer: principal,
+    seller: principal,
+    amount: uint,
+    state: (string-ascii 20),
+    created-at: uint,
+    release-height: uint
+  }
+)
+
+(define-data-var last-escrow-id uint u0)
+
+;; Public Functions
+(define-public (create-escrow (seller principal) (amount uint))
+  (let
+    (
+      (escrow-id (+ (var-get last-escrow-id) u1))
+      (release-height (+ block-height ESCROW_LOCK_PERIOD))
+    )
+    (asserts! (> amount u0) (err ERR_INVALID_AMOUNT))
+    (match (stx-transfer? amount tx-sender (as-contract tx-sender))
+      success 
+        (begin
+          (map-set Escrows
+            { escrow-id: escrow-id }
+            {
+              buyer: tx-sender,
+              seller: seller,
+              amount: amount,
+              state: "locked",
+              created-at: block-height,
+              release-height: release-height
+            }
+          )
+          (var-set last-escrow-id escrow-id)
+          (ok escrow-id))
+      error (err ERR_TRANSFER_FAILED)
+    )
+  )
+)
+
+(define-public (release-funds (escrow-id uint))
+  (let
+    (
+      (escrow (unwrap! (map-get? Escrows { escrow-id: escrow-id }) (err ERR_ESCROW_NOT_FOUND)))
+      (buyer (get buyer escrow))
+      (seller (get seller escrow))
+      (amount (get amount escrow))
+    )
+    (asserts! (or (is-eq tx-sender buyer) (is-eq tx-sender seller)) (err ERR_NOT_BUYER_OR_SELLER))
+    (asserts! (is-eq (get state escrow) "locked") (err ERR_ALREADY_RELEASED))
+    (asserts! (>= block-height (get release-height escrow)) (err ERR_TOO_EARLY_TO_RELEASE))
+    (match (as-contract (stx-transfer? amount tx-sender seller))
+      success 
+        (begin
+          (map-set Escrows
+            { escrow-id: escrow-id }
+            (merge escrow { state: "released" })
+          )
+          (ok true))
+      error (err ERR_TRANSFER_FAILED)
+    )
+  )
+)
+
+(define-public (refund-buyer (escrow-id uint))
+  (let
+    (
+      (escrow (unwrap! (map-get? Escrows { escrow-id: escrow-id }) (err ERR_ESCROW_NOT_FOUND)))
+      (buyer (get buyer escrow))
+      (amount (get amount escrow))
+    )
+    (asserts! (is-eq tx-sender CONTRACT_OWNER) (err ERR_NOT_AUTHORIZED))
+    (asserts! (is-eq (get state escrow) "locked") (err ERR_ALREADY_RELEASED))
+    (match (as-contract (stx-transfer? amount tx-sender buyer))
+      success 
+        (begin
+          (map-set Escrows
+            { escrow-id: escrow-id }
+            (merge escrow { state: "refunded" })
+          )
+          (ok true))
+      error (err ERR_TRANSFER_FAILED)
+    )
+  )
+)
+
+(define-read-only (get-escrow (escrow-id uint))
+  (map-get? Escrows { escrow-id: escrow-id })
+)
+
+(define-read-only (get-last-escrow-id)
+  (ok (var-get last-escrow-id))
+)
+
+;; Initialize contract
+(begin
+  (print "EscrowService contract initialized")
+  (ok true)
+)

--- a/contracts/UserProfile.clar
+++ b/contracts/UserProfile.clar
@@ -1,0 +1,138 @@
+;; UserProfile: Manages user profiles, ratings, and reputation for BuyNsell marketplace
+
+;; Constants
+(define-constant CONTRACT_OWNER tx-sender)
+(define-constant ERR_NOT_AUTHORIZED (err u100))
+(define-constant ERR_USER_NOT_FOUND (err u101))
+(define-constant ERR_INVALID_RATING (err u102))
+(define-constant ERR_SELF_RATING (err u103))
+(define-constant ERR_ALREADY_REGISTERED (err u104))
+
+;; Data Maps
+(define-map Users principal
+  {
+    username: (string-utf8 64),
+    bio: (string-utf8 256),
+    email: (string-utf8 64),
+    registration-date: uint,
+    total-ratings: uint,
+    rating-sum: uint,
+    reputation-score: uint
+  }
+)
+
+(define-map UserAuthorization principal bool)
+
+;; Read-only functions
+
+(define-read-only (get-user-profile (user principal))
+  (map-get? Users user)
+)
+
+(define-read-only (get-user-rating (user principal))
+  (let (
+    (user-data (unwrap! (map-get? Users user) (err ERR_USER_NOT_FOUND)))
+    (total-ratings (get total-ratings user-data))
+    (rating-sum (get rating-sum user-data))
+  )
+  (if (> total-ratings u0)
+    (ok (/ rating-sum total-ratings))
+    (ok u0)
+  ))
+)
+
+(define-read-only (is-user-authorized (user principal))
+  (default-to false (map-get? UserAuthorization user))
+)
+
+;; Public functions
+
+(define-public (register-user (username (string-utf8 64)) (bio (string-utf8 256)) (email (string-utf8 64)))
+  (let (
+    (existing-user (map-get? Users tx-sender))
+  )
+  (asserts! (is-none existing-user) (err ERR_ALREADY_REGISTERED))
+  (map-set Users tx-sender
+    {
+      username: username,
+      bio: bio,
+      email: email,
+      registration-date: block-height,
+      total-ratings: u0,
+      rating-sum: u0,
+      reputation-score: u0
+    }
+  )
+  (map-set UserAuthorization tx-sender true)
+  (ok true))
+)
+
+(define-public (update-profile (bio (string-utf8 256)) (email (string-utf8 64)))
+  (let (
+    (user-data (unwrap! (map-get? Users tx-sender) (err ERR_USER_NOT_FOUND)))
+  )
+  (map-set Users tx-sender
+    (merge user-data
+      {
+        bio: bio,
+        email: email
+      }
+    )
+  )
+  (ok true))
+)
+
+(define-public (rate-user (user principal) (rating uint))
+  (let (
+    (user-data (unwrap! (map-get? Users user) (err ERR_USER_NOT_FOUND)))
+  )
+  (asserts! (not (is-eq tx-sender user)) (err ERR_SELF_RATING))
+  (asserts! (and (>= rating u1) (<= rating u5)) (err ERR_INVALID_RATING))
+  (map-set Users user
+    (merge user-data
+      {
+        total-ratings: (+ (get total-ratings user-data) u1),
+        rating-sum: (+ (get rating-sum user-data) rating)
+      }
+    )
+  )
+  (ok true))
+)
+
+(define-public (calculate-reputation (user principal))
+  (let (
+    (user-data (unwrap! (map-get? Users user) (err ERR_USER_NOT_FOUND)))
+    (total-ratings (get total-ratings user-data))
+    (rating-sum (get rating-sum user-data))
+    (avg-rating (if (> total-ratings u0) (/ rating-sum total-ratings) u0))
+    (new-reputation (+ (* avg-rating u20) (* total-ratings u2)))
+  )
+  (map-set Users user
+    (merge user-data
+      {
+        reputation-score: new-reputation
+      }
+    )
+  )
+  (ok new-reputation))
+)
+
+(define-public (authorize-user (user principal))
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT_OWNER) (err ERR_NOT_AUTHORIZED))
+    (ok (map-set UserAuthorization user true))
+  )
+)
+
+(define-public (revoke-authorization (user principal))
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT_OWNER) (err ERR_NOT_AUTHORIZED))
+    (ok (map-set UserAuthorization user false))
+  )
+)
+
+;; Initialize contract
+(begin
+  (map-set UserAuthorization CONTRACT_OWNER true)
+  (print "UserProfile contract initialized")
+)

--- a/contracts/UserProfile.clar
+++ b/contracts/UserProfile.clar
@@ -9,6 +9,10 @@
 (define-constant ERR_ALREADY_REGISTERED (err u104))
 (define-constant ERR_INVALID_INPUT (err u105))
 (define-constant ERR_DATA_STORE_FAILURE (err u106))
+(define-constant ERR_INVALID_PRINCIPAL (err u107))
+(define-constant ERR_INVALID_USERNAME (err u108))
+(define-constant ERR_INVALID_BIO (err u109))
+(define-constant ERR_INVALID_EMAIL (err u110))
 
 ;; Data Maps
 (define-map Users principal
@@ -29,6 +33,28 @@
 
 (define-private (is-valid-string (str (string-utf8 256)) (max-len uint))
   (and (>= (len str) u1) (<= (len str) max-len))
+)
+
+(define-private (is-valid-principal (user principal))
+  (not (is-eq user (as-contract tx-sender)))
+)
+
+(define-private (validate-username (username (string-utf8 64)))
+  (if (is-valid-string username u64)
+    (ok username)
+    (err ERR_INVALID_USERNAME))
+)
+
+(define-private (validate-bio (bio (string-utf8 256)))
+  (if (is-valid-string bio u256)
+    (ok bio)
+    (err ERR_INVALID_BIO))
+)
+
+(define-private (validate-email (email (string-utf8 64)))
+  (if (is-valid-string email u64)
+    (ok email)
+    (err ERR_INVALID_EMAIL))
 )
 
 (define-private (set-user-data (user principal) (data {
@@ -71,18 +97,16 @@
 (define-public (register-user (username (string-utf8 64)) (bio (string-utf8 256)) (email (string-utf8 64)))
   (let (
     (existing-user (map-get? Users tx-sender))
+    (validated-username (try! (validate-username username)))
+    (validated-bio (try! (validate-bio bio)))
+    (validated-email (try! (validate-email email)))
   )
   (asserts! (is-none existing-user) (err ERR_ALREADY_REGISTERED))
-  (asserts! (and 
-              (is-valid-string username u64)
-              (is-valid-string bio u256)
-              (is-valid-string email u64)) 
-            (err ERR_INVALID_INPUT))
   (unwrap! (set-user-data tx-sender
     {
-      username: username,
-      bio: bio,
-      email: email,
+      username: validated-username,
+      bio: validated-bio,
+      email: validated-email,
       registration-date: block-height,
       total-ratings: u0,
       rating-sum: u0,
@@ -94,67 +118,73 @@
 (define-public (update-profile (bio (string-utf8 256)) (email (string-utf8 64)))
   (match (map-get? Users tx-sender)
     user-data 
-      (begin
-        (asserts! (and 
-                    (is-valid-string bio u256)
-                    (is-valid-string email u64)) 
-                  (err ERR_INVALID_INPUT))
-        (unwrap! (set-user-data tx-sender
-          (merge user-data
-            {
-              bio: bio,
-              email: email
-            }
-          ))
-          (err ERR_DATA_STORE_FAILURE))
-        (ok true))
+      (let (
+        (validated-bio (try! (validate-bio bio)))
+        (validated-email (try! (validate-email email)))
+      )
+      (unwrap! (set-user-data tx-sender
+        (merge user-data
+          {
+            bio: validated-bio,
+            email: validated-email
+          }
+        ))
+        (err ERR_DATA_STORE_FAILURE))
+      (ok true))
     (err ERR_USER_NOT_FOUND)
   )
 )
 
 (define-public (rate-user (user principal) (rating uint))
-  (match (map-get? Users user)
-    user-data
-      (begin
-        (asserts! (not (is-eq tx-sender user)) (err ERR_SELF_RATING))
-        (asserts! (and (>= rating u1) (<= rating u5)) (err ERR_INVALID_RATING))
-        (unwrap! (set-user-data user
-          (merge user-data
-            {
-              total-ratings: (+ (get total-ratings user-data) u1),
-              rating-sum: (+ (get rating-sum user-data) rating)
-            }
-          ))
-          (err ERR_DATA_STORE_FAILURE))
-        (ok true))
-    (err ERR_USER_NOT_FOUND)
+  (begin
+    (asserts! (is-valid-principal user) (err ERR_INVALID_PRINCIPAL))
+    (match (map-get? Users user)
+      user-data
+        (begin
+          (asserts! (not (is-eq tx-sender user)) (err ERR_SELF_RATING))
+          (asserts! (and (>= rating u1) (<= rating u5)) (err ERR_INVALID_RATING))
+          (unwrap! (set-user-data user
+            (merge user-data
+              {
+                total-ratings: (+ (get total-ratings user-data) u1),
+                rating-sum: (+ (get rating-sum user-data) rating)
+              }
+            ))
+            (err ERR_DATA_STORE_FAILURE))
+          (ok true))
+      (err ERR_USER_NOT_FOUND)
+    )
   )
 )
 
 (define-public (calculate-reputation (user principal))
-  (match (map-get? Users user)
-    user-data
-      (let (
-        (total-ratings (get total-ratings user-data))
-        (rating-sum (get rating-sum user-data))
-        (avg-rating (if (> total-ratings u0) (/ rating-sum total-ratings) u0))
-        (new-reputation (+ (* avg-rating u20) (* total-ratings u2)))
-      )
-      (unwrap! (set-user-data user
-        (merge user-data
-          {
-            reputation-score: new-reputation
-          }
-        ))
-        (err ERR_DATA_STORE_FAILURE))
-      (ok new-reputation))
-    (err ERR_USER_NOT_FOUND)
+  (begin
+    (asserts! (is-valid-principal user) (err ERR_INVALID_PRINCIPAL))
+    (match (map-get? Users user)
+      user-data
+        (let (
+          (total-ratings (get total-ratings user-data))
+          (rating-sum (get rating-sum user-data))
+          (avg-rating (if (> total-ratings u0) (/ rating-sum total-ratings) u0))
+          (new-reputation (+ (* avg-rating u20) (* total-ratings u2)))
+        )
+        (unwrap! (set-user-data user
+          (merge user-data
+            {
+              reputation-score: new-reputation
+            }
+          ))
+          (err ERR_DATA_STORE_FAILURE))
+        (ok new-reputation))
+      (err ERR_USER_NOT_FOUND)
+    )
   )
 )
 
 (define-public (authorize-user (user principal))
   (begin
     (asserts! (is-eq tx-sender CONTRACT_OWNER) (err ERR_NOT_AUTHORIZED))
+    (asserts! (is-valid-principal user) (err ERR_INVALID_PRINCIPAL))
     (ok (map-set UserAuthorization user true))
   )
 )
@@ -162,6 +192,7 @@
 (define-public (revoke-authorization (user principal))
   (begin
     (asserts! (is-eq tx-sender CONTRACT_OWNER) (err ERR_NOT_AUTHORIZED))
+    (asserts! (is-valid-principal user) (err ERR_INVALID_PRINCIPAL))
     (ok (map-set UserAuthorization user false))
   )
 )

--- a/tests/EscrowService.test.ts
+++ b/tests/EscrowService.test.ts
@@ -1,0 +1,21 @@
+
+import { describe, expect, it } from "vitest";
+
+const accounts = simnet.getAccounts();
+const address1 = accounts.get("wallet_1")!;
+
+/*
+  The test below is an example. To learn more, read the testing documentation here:
+  https://docs.hiro.so/stacks/clarinet-js-sdk
+*/
+
+describe("example tests", () => {
+  it("ensures simnet is well initalised", () => {
+    expect(simnet.blockHeight).toBeDefined();
+  });
+
+  // it("shows an example", () => {
+  //   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
+  //   expect(result).toBeUint(0);
+  // });
+});

--- a/tests/UserProfile.test.ts
+++ b/tests/UserProfile.test.ts
@@ -1,0 +1,21 @@
+
+import { describe, expect, it } from "vitest";
+
+const accounts = simnet.getAccounts();
+const address1 = accounts.get("wallet_1")!;
+
+/*
+  The test below is an example. To learn more, read the testing documentation here:
+  https://docs.hiro.so/stacks/clarinet-js-sdk
+*/
+
+describe("example tests", () => {
+  it("ensures simnet is well initalised", () => {
+    expect(simnet.blockHeight).toBeDefined();
+  });
+
+  // it("shows an example", () => {
+  //   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
+  //   expect(result).toBeUint(0);
+  // });
+});


### PR DESCRIPTION
Key changes in this fixed version:

1. In the rate-user function, we've wrapped the unwrap! call in a begin block and added an explicit (ok true) return at the end. This ensures that both branches of the match expression return the same type (a response).

The rest of the contract remains the same, as it was already consistent in its return types.